### PR TITLE
Dockerfile: switch to debian:slim with a build stage

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,1 +1,2 @@
 target/*
+Dockerfile

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,8 @@
-FROM rust
+FROM rust:slim-bullseye as builder
+COPY . /root
+RUN cargo install --path /root
 
-WORKDIR /
-COPY . .
-
-RUN cargo install --path .
-
+FROM debian:bullseye-slim
+COPY --from=builder /usr/local/cargo/bin/ffly /usr/local/bin/ffly
 EXPOSE 46600
-
-CMD ["ffly --host 0.0.0.0"]
+CMD ["ffly", "--host", "0.0.0.0", "--port", "46600"]


### PR DESCRIPTION
- Reduce the docker image size (on disk, uncompressed) from 1.7GB to 90MB.
- Fix CMD.
